### PR TITLE
Added references for external libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,23 @@ The BibTeX code would thus be:
 > pages = {788--798},  
 > year = {2018}  
 >}  
+
+Please also cite the second publication:
+N. Niemeyer, P. Eschenbach, M. Bensberg, J. Tölle, L. Hellmann, L. Lampe, A. Massolle, A. Rikus, D. Schnieders, J. P. Unsleber, and J. Neugebauer,
+The subsystem quantum chemistry program Serenity,
+*Wiley Interdiscip. Rev. Comput. Mol. Sci.*, **13**, e1647, (2023).
+
+The BibTeX code would thus be:  
+>@article{serenity_update,
+>  title={The Subsystem Quantum Chemistry Program Serenity},
+>  author={Niemeyer, Niklas and Eschenbach, Patrick and Bensberg, Moritz and T{\"o}lle, Johannes and Hellmann, Lars and Lampe, Lukas and Massolle, Anja and Rikus, Anton and Schnieders, David and Unsleber, Jan P and Neugebauer, Johannes},
+>  journal={Wiley Interdiscip. Rev. Comput. Mol. Sci.},
+>  volume={13},
+>  number={3},
+>  pages={e1647},
+>  year={2023},
+>  publisher={Wiley Online Library}
+>}
   
 In order to allow others to reproduce your data and to give credit to all recent developers,
 please also reference the version of Serenity used by citing the correct code reference
@@ -186,7 +203,19 @@ generated on Zenodo. The following DOI will always link to the newest version of
 
 [10.5281/zenodo.4017420](https://doi.org/10.5281/zenodo.4017420)
 
-For specific versions, please use the appropriate DOI.  
+For specific versions, please use the appropriate DOI.
+
+Serenity relies on a few external libraries. Please cite Libint:  
+Libint: A library for the evaluation of molecular integrals of many-body operators  over Gaussian functions, v2.7.0-beta6  Edward F. Valeev, http://libint.valeyev.net/ .
+
+In case density functionals (for exchange-correlation or kinetic energy) are used, depending on the settings when compiling, please cite either Libxc or XCFun.  
+Libxc (6.1.0): S. Lehtola, C. Steigemann, M. J.T. Oliveira, and M. A.L. Marques. SoftwareX 7, 1–5 (2018). DOI: 10.1016/j.softx.2017.11.002  
+XCFun (v2.0.2):  Ekström, U. (2020). XCFun: A library of exchange-correlation functionals with  arbitrary-order derivatives. Zenodo. https://doi.org/10.5281/zenodo.3946698 
+
+Integrals over effective core potentials are provided by Libecpint.  
+Libecpint (1.0.7) :  R. A. Shaw, J. G. Hill, J. Chem. Phys. 147, 074108 (2017); doi: 10.1063/1.4986887
+
+Also, please include the scientific citations for the basis sets and density functionals you use.
 
 ## Contact
 

--- a/manual/SerenityUserManual.bib
+++ b/manual/SerenityUserManual.bib
@@ -13,6 +13,47 @@
   language = {en},
   number = {19}
 }
+@misc{Libint2.7.0,
+  title={{Libint: A library for the evaluation of molecular integrals of 
+          many-body operators over Gaussian functions}},
+  author={Valeev, Edward F and Fermann, JT},
+  howpublished={https://github.com/evaleev/libint},
+  year={2020},
+  note={version 2.7.0-beta6}
+}
+@software{XCFun2.0.2,
+  author       = {Ekstr{\"o}m, Ulf},
+  title        = {{XCFun: A library of exchange-correlation 
+                    functionals with arbitrary-order derivatives}},
+  year         = 2020,
+  publisher    = {Zenodo},
+  version      = {v2.0.2},
+  doi          = {10.5281/zenodo.3946698},
+  url          = {https://doi.org/10.5281/zenodo.3946698}
+}
+@article{Libxc,
+  title={{Recent developments in libxc—A comprehensive library of functionals
+        for density functional theory}},
+  author={Lehtola, Susi and Steigemann, Conrad and Oliveira, Micael JT
+          and Marques, Miguel AL},
+  journal={SoftwareX},
+  volume={7},
+  pages={1--5},
+  year={2018},
+  publisher={Elsevier}
+}
+@article{Libecpint,
+  author = {Shaw, Robert A. and Hill, J. Grant},
+  doi = {10.1063/1.4986887},
+  issn = {0021-9606},
+  journal = {J. Chem. Phys.},
+  pages = {074108},
+  title = {{Prescreening and efficiency in the evaluation of integrals
+  over ab initio effective core potentials}},
+  url = {http://aip.scitation.org/doi/10.1063/1.4986887},
+  volume = {147},
+  year = {2017}
+}
 @article{soda2000,
   title = {Ab Initio Computations of Effective Exchange Integrals for {{H}}\textendash{{H}}, {{H}}\textendash{{He}}\textendash{{H}} and {{Mn2O2}} Complex: Comparison of Broken-Symmetry Approaches},
   shorttitle = {Ab Initio Computations of Effective Exchange Integrals for {{H}}\textendash{{H}}, {{H}}\textendash{{He}}\textendash{{H}} and {{Mn2O2}} Complex},

--- a/manual/SerenityUserManual.tex
+++ b/manual/SerenityUserManual.tex
@@ -3528,13 +3528,104 @@ The BibTeX code would thus be:
   year = {2018}
 }
 \end{lstlisting}
+Please also cite the second publication:\\
+\\
+N. Niemeyer, P. Eschenbach, M. Bensberg, J. T{\"o}lle, L. Hellmann, L. Lampe, A. Massolle, A. Rikus, D. Schnieders, J. P. Unsleber, and J. Neugebauer,
+''The subsystem quantum chemistry program Serenity'',
+\textit{Wiley Interdiscip. Rev. Comput. Mol. Sci.}, \textbf{13}, e1647, (2023).\\
+\\
+The BibTeX code would thus be:  
+\begin{lstlisting}
+@article{serenity_update,  
+title={{The Subsystem Quantum Chemistry Program Serenity}},  
+author={Niemeyer, Niklas and Eschenbach, Patrick and Bensberg, Moritz
+        and T{\"o}lle, Johannes and Hellmann, Lars and Lampe, Lukas 
+        and Massolle, Anja and Rikus, Anton and Schnieders, David 
+        and Unsleber, Jan P and Neugebauer, Johannes},  
+journal={Wiley Interdiscip. Rev. Comput. Mol. Sci.},  
+volume={13},  
+pages={e1647},  
+year={2023},  
+publisher={Wiley Online Library}
+}
+\end{lstlisting}
 In order to allow others to reproduce your data and to give credit to all recent developers,
 please also reference the version of Serenity used by citing the correct code reference
 generated on Zenodo. The following DOI will always link to the newest version of the code:\\
 \\
 \url{https://doi.org/10.5281/zenodo.4017420}\\
 \\
-For specific versions, please use the appropriate DOI.\\ 
+For specific versions, please use the appropriate DOI.\\
+\\
+Serenity relies on a few external libraries. Please cite Libint: \cite{Libint2.7.0}\\
+\\
+Libint: A library for the evaluation of molecular integrals of many-body operators  over Gaussian functions, v2.7.0-beta6, Edward F. Valeev, http://libint.valeyev.net/ \\
+\\
+BibTeX:
+\begin{lstlisting}
+  @misc{valeev2020libint,
+  title={{Libint: A library for the evaluation of molecular integrals of 
+          many-body operators over Gaussian functions}},
+  author={Valeev, Edward F and Fermann, JT},
+  howpublished={https://github.com/evaleev/libint},
+  year={2020},
+  note={version 2.7.0-beta6}
+}
+\end{lstlisting}
+In case density functionals (for exchange-correlation or kinetic energy) are used, depending on the settings when compiling, please cite either Libxc \cite{Libxc} or XCFun \cite{XCFun2.0.2}.\\
+\\
+Libxc (6.1.0): S. Lehtola, C. Steigemann, M. J.T. Oliveira, and M. A.L. Marques. SoftwareX 7, 1-5 (2018). DOI: 10.1016/j.softx.2017.11.002\\
+\\
+BibTeX:
+\begin{lstlisting}
+  @article{lehtola2018recent,
+  title={{Recent developments in libxc - A comprehensive library of functionals
+        for density functional theory}},
+  author={Lehtola, Susi and Steigemann, Conrad and Oliveira, Micael JT
+          and Marques, Miguel AL},
+  journal={SoftwareX},
+  volume={7},
+  pages={1--5},
+  year={2018},
+  publisher={Elsevier}
+}
+\end{lstlisting}
+XCFun (v2.0.2):  Ekström, U. (2020). XCFun: A library of exchange-correlation functionals with  arbitrary-order derivatives. Zenodo. https://doi.org/10.5281/zenodo.3946698  \\
+\\
+BibTeX:
+\begin{lstlisting}
+  @software{ekstrom_2020_3946698,
+  author       = {Ekstr{\"o}m, Ulf},
+  title        = {{XCFun: A library of exchange-correlation 
+                   functionals with arbitrary-order derivatives}},
+  year         = 2020,
+  publisher    = {Zenodo},
+  version      = {v2.0.2},
+  doi          = {10.5281/zenodo.3946698},
+  url          = {https://doi.org/10.5281/zenodo.3946698}
+  note         = {DOI: 10.5281/zenodo.3946698}
+}
+\end{lstlisting}
+\newpage
+\noindent Integrals over effective core potentials are provided by Libecpint \cite{Libecpint}.\\
+Libecpint (1.0.7) :  R. A. Shaw, J. G. Hill, J. Chem. Phys. 147, 074108 (2017); doi: 10.1063/1.4986887\\
+\\
+BibTeX:
+\begin{lstlisting}
+@article{Libecpint,
+author = {Shaw, Robert A. and Hill, J. Grant},
+doi = {10.1063/1.4986887},
+journal = {J. Chem. Phys.},
+pages = {074108},
+title = {{Prescreening and efficiency in the evaluation of integrals
+ over ab initio effective core potentials}},
+url = {http://aip.scitation.org/doi/10.1063/1.4986887},
+volume = {147},
+year = {2017}
+}
+\end{lstlisting}
+
+Also, please include the scientific citations for the basis sets and density functionals you use.
 
 \chapter{License and Warranty}
 This manual is part of \serenity. The full license file can be found in the appendix (Appendix~\ref{sec:lgpl})\\

--- a/src/dft/functionals/wrappers/LibXC.cpp
+++ b/src/dft/functionals/wrappers/LibXC.cpp
@@ -120,6 +120,21 @@ FunctionalData<T> LibXC<T>::calcData(FUNCTIONAL_DATA_TYPE type, const Functional
   return funcData;
 }
 
+template<Options::SCF_MODES SCFMode>
+std::string LibXC<SCFMode>::version() {
+  return xc_version_string();
+}
+
+template<Options::SCF_MODES SCFMode>
+std::string LibXC<SCFMode>::reference() {
+  return xc_reference();
+}
+
+template<Options::SCF_MODES SCFMode>
+std::string LibXC<SCFMode>::referenceDOI() {
+  return xc_reference_doi();
+}
+
 template<>
 Eigen::MatrixXd LibXC<RESTRICTED>::calculateSigma(const Gradient<DensityOnGrid<RESTRICTED>>& gradient,
                                                   const unsigned int& iGridStart, const unsigned int& blocksize) {

--- a/src/dft/functionals/wrappers/LibXC.h
+++ b/src/dft/functionals/wrappers/LibXC.h
@@ -64,6 +64,21 @@ class LibXC {
                              const std::shared_ptr<DensityOnGridController<T>> densityOnGridController,
                              unsigned int order = 1);
 
+  /**
+   * @brief Returns the version number of Libxc.
+   */
+  static std::string version();
+
+  /**
+   * @brief Returns the publication describing Libxc.
+   */
+  static std::string reference();
+
+  /**
+   * @brief Returns the DOI of the Libxc publication.
+   */
+  static std::string referenceDOI();
+
  private:
   unsigned int _maxBlockSize;
 

--- a/src/integrals/wrappers/Libint.h
+++ b/src/integrals/wrappers/Libint.h
@@ -95,7 +95,7 @@ struct IntegralType {
  * (Yes, this singleton is not correctly destroyed however
  *  we will live with this for now)
  *
- * Currently interfaced: libint-2.2.0-beta1
+ * Currently interfaced: libint-2.7.0-beta6
  * (https://github.com/evaleev/libint)
  *
  * Usage:

--- a/src/io/FormattedOutput.cpp
+++ b/src/io/FormattedOutput.cpp
@@ -20,6 +20,7 @@
 /* Include Class Header*/
 #include "io/FormattedOutput.h"
 /* Include Serenity Internal Headers */
+#include "dft/functionals/wrappers/LibXC.h"
 #include "memory/MemoryManager.h"
 #include "misc/Timing.h"
 /* Include Std and External Headers */
@@ -105,6 +106,31 @@ void printRunStartInfo() {
   std::cout << "    Git Branch        :   " << GIT_BRANCH << std::endl;
   std::cout << "    Serenity Home     :   "
             << std::string(std::getenv("SERENITY_HOME") ? std::getenv("SERENITY_HOME") : "$SERENITY_HOME UNKNOWN") << std::endl
+            << std::endl;
+
+  printSmallCaption("Citations");
+  std::cout << "    First publication :\n  J. P. Unsleber, T. Dresselhaus, K. Klahr, D. Schnieders, M. Böckers, D. "
+               "Barton\n  and J. Neugebauer, Serenity: A Subsystem Quantum Chemistry Program,\n  J. Comput. Chem., 39, "
+               "788-798, (2018).\n"
+            << std::endl;
+  std::cout << "    Update paper      :\n  N. Niemeyer, P. Eschenbach, M. Bensberg, J. Toelle, L. Hellmann, L. "
+               "Lampe,\n  A. Massolle, A. Rikus, D. Schnieders, J. P. Unsleber, and J. Neugebauer,\n  The subsystem "
+               "quantum chemistry program Serenity,\n  Wiley Interdiscip. Rev. Comput. Mol. Sci., 13, e1647, (2023).\n"
+            << std::endl;
+  std::cout << "    Libint (2.7.0-b6) :\n  Libint: A library for the evaluation of molecular integrals of many-body "
+               "operators\n  over Gaussian functions, v2.7.0-beta6  Edward F. Valeev, http://libint.valeyev.net/ .\n"
+            << std::endl;
+#ifdef SERENITY_USE_LIBXC
+  std::cout << "    Libxc (" << LibXC<RESTRICTED>::version() << ")     :\n  " << LibXC<RESTRICTED>::reference()
+            << "\n  " << LibXC<RESTRICTED>::referenceDOI() << std::endl
+            << std::endl;
+#endif /* SERENITY_USE_LIBXC */
+#ifdef SERENITY_USE_XCFUN
+  std::cout << "    XCFun (v2.0.2)    :\n  Ekström, U. (2020). XCFun: A library of exchange-correlation functionals "
+               "with\n  arbitrary-order derivatives. Zenodo. https://doi.org/10.5281/zenodo.3946698\n\n";
+#endif /* SERENITY_USE_XCFUN */
+  std::cout << "    Libecpint (1.0.7) :\n  R. A. Shaw, J. G. Hill, J. Chem. Phys. 147, 074108 (2017); doi: "
+               "10.1063/1.4986887\n"
             << std::endl;
 
   printSmallCaption("Program started");


### PR DESCRIPTION
Modified `README`, manual and `FormattedOutput` to reference Libint, Libxc, XCFun and Libecpint